### PR TITLE
Add initial version of VS Code support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ test-results/
 playwright-report/
 playwright/.cache/
 lib/
+.vscode-test
 
 examples/workflow-test/server/
 examples/workflow-test/playwright/.storage/*.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,6 +33,19 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Run tests (VS Code)",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": ["test:vscode"],
+      "presentation": {
+        "group": "GLSP-Playwright launch configurations",
+        "order": 1
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Run current test (Standalone)",
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
@@ -51,6 +64,19 @@
       "internalConsoleOptions": "neverOpen",
       "runtimeExecutable": "yarn",
       "runtimeArgs": ["test:theia", "${fileBasename}"],
+      "presentation": {
+        "group": "GLSP-Playwright launch configurations",
+        "order": 1
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Run current test (VS Code)",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": ["test:vscode", "${fileBasename}"],
       "presentation": {
         "group": "GLSP-Playwright launch configurations",
         "order": 1
@@ -80,6 +106,22 @@
       "internalConsoleOptions": "neverOpen",
       "runtimeExecutable": "yarn",
       "runtimeArgs": ["test:theia", "--ui", "${fileBasename}"],
+      "env": {
+        "PWDEBUG": "1"
+      },
+      "presentation": {
+        "group": "GLSP-Playwright launch configurations",
+        "order": 1
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Inspect current file (VS Code)",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": ["test:vscode", "--ui", "${fileBasename}"],
       "env": {
         "PWDEBUG": "1"
       },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -50,6 +50,18 @@
         "panel": "new"
       },
       "problemMatcher": []
+    },
+    {
+      "label": "[Playwright] Test VS Code",
+      "detail": "Run test cases for VS Code integration",
+      "type": "shell",
+      "group": "test",
+      "command": "cd examples/workflow-test && yarn test:vscode",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": []
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project is built with `yarn`.
 
 The workflow diagram is a consistent example provided by all GLSP components.
 The example implements a simple flow chart diagram editor with different types of nodes and edges (see below).
-The example can be used to try out different GLSP features, as well as several available integrations with IDE platforms (Theia, VSCode, Eclipse, Standalone).
+The example can be used to try out different GLSP features, as well as several available integrations with IDE platforms (Theia, VS Code, Eclipse, Standalone).
 
 The example test cases test the features provided by the GLSP client. The test cases in the [Workflow Example](https://github.com/eclipse-glsp/glsp-playwright/examples/workflow-test) demonstrate all supported features.
 

--- a/examples/workflow-test/.env.example
+++ b/examples/workflow-test/.env.example
@@ -1,4 +1,10 @@
-GLSP_SERVER_PORT=8081
+# For Theia and VSCode instances
+GLSP_SERVER_DEBUG="true"
+GLSP_SERVER_PORT="8081"
+GLSP_WEBSOCKET_PATH="workflow"
 
+# Configurations
 STANDALONE_URL="file:///.../glsp-client/examples/workflow-standalone/app/diagram.html"
 THEIA_URL="http://localhost:3000"
+VSCODE_VSIX_ID="eclipse-glsp.workflow-vscode-example"
+VSCODE_VSIX_PATH="/.../glsp-vscode-integration/example/workflow/extension/workflow-vscode-example-1.1.0-next.vsix"

--- a/examples/workflow-test/README.md
+++ b/examples/workflow-test/README.md
@@ -24,19 +24,7 @@ Please clone it to your machine and follow the steps to install it.
 
 Next, create a new `.env` file with the content of `.env.example` in the `workflow-test` folder.
 This file contains private information about your environment, so do not commit it.
-Afterward, provide for the keys in `.env` file the necessary data, e.g.,
-
-```env
-GLSP_SERVER_PORT=8081
-
-STANDALONE_URL="file:///<path-to-the-glsp-client-folder>/glsp-client/examples/workflow-standalone/app/diagram.html"
-THEIA_URL="http://localhost:3000"
-```
-
-The `STANDALONE_URL` is the URL of the standalone version of the GLSP-Client.
-You should also be able to open it in the browser.
-
-The `THEIA_URL` is the URL of the running Theia editor instance.
+Afterward, provide for the keys in `.env` file the necessary data.
 
 ## Building the examples
 
@@ -66,6 +54,17 @@ Afterward, the test cases can be executed by executing the task `[Playwright] Te
 
 ```bash
 yarn test:theia
+```
+
+## Testing the VS Code version
+
+GLSP-Playwright will download and start the necessary VS Code instances automatically.
+
+The user needs to provide the path of the `vsix` file in the `.env` file.
+Then the test cases can be executed by executing the task `[Playwright] Test VS Code` or the following command in the _workflow-test_ folder:
+
+```bash
+yarn test:vscode
 ```
 
 ## Development

--- a/examples/workflow-test/package.json
+++ b/examples/workflow-test/package.json
@@ -37,10 +37,11 @@
     "lint:all": "yarn check-types && yarn lint",
     "lint:fix": "yarn lint --fix",
     "prepare": "yarn clean && yarn build && yarn lint && playwright install",
-    "start:server": "node node_modules/@eclipse-glsp-examples/workflow-server-bundled/wf-glsp-server-node.js -w -p 8081",
+    "start:server": "node node_modules/@eclipse-glsp-examples/workflow-server-bundled/wf-glsp-server-node.js",
     "test": "playwright test",
     "test:standalone": "yarn test --project=standalone",
     "test:theia": "yarn test --project=theia",
+    "test:vscode": "yarn test --project=vscode",
     "watch": "tsc -w"
   },
   "devDependencies": {

--- a/examples/workflow-test/tests/features/tool-palette.spec.ts
+++ b/examples/workflow-test/tests/features/tool-palette.spec.ts
@@ -15,13 +15,29 @@
  ********************************************************************************/
 import { Marker } from '@eclipse-glsp/glsp-playwright';
 import { GLSPApp } from '@eclipse-glsp/glsp-playwright/glsp';
-import { expect, test } from '@eclipse-glsp/glsp-playwright/test';
+import { createParameterizedIntegrationData, expect, test } from '@eclipse-glsp/glsp-playwright/test';
 import { WorkflowApp } from '../../src/app/workflow-app';
 import { WorkflowToolPalette } from '../../src/features/tool-palette/workflow-tool-palette';
 import { Edge } from '../../src/graph/elements/edge.po';
 import { TaskAutomated } from '../../src/graph/elements/task-automated.po';
 import { TaskManual } from '../../src/graph/elements/task-manual.po';
 import { WorkflowGraph } from '../../src/graph/workflow.graph';
+
+const integrationData = createParameterizedIntegrationData<{
+    nodes: string;
+    edges: string;
+}>({
+    default: {
+        edges: 'Edges',
+        nodes: 'Nodes'
+    },
+    override: {
+        VSCode: {
+            edges: 'EDGES',
+            nodes: 'NODES'
+        }
+    }
+});
 
 test.describe('The tool palette', () => {
     let app: WorkflowApp;
@@ -37,13 +53,13 @@ test.describe('The tool palette', () => {
         toolPalette = app.toolPalette;
     });
 
-    test('should allow to access the content items', async () => {
+    test('should allow to access the content items', async ({ integration }) => {
         await toolPalette.waitForVisible();
 
         const groups = await toolPalette.content.toolGroups();
         expect(groups.length).toBe(2);
-        expect(await groups[0].header()).toBe('Nodes');
-        expect(await groups[1].header()).toBe('Edges');
+        expect(await groups[0].header()).toBe(integrationData[integration.type].nodes);
+        expect(await groups[1].header()).toBe(integrationData[integration.type].edges);
 
         const elements0 = await groups[0].items();
         expect(elements0.length).toBe(7);
@@ -54,7 +70,7 @@ test.describe('The tool palette', () => {
         expect(await elements1[1].text()).toBe('Weighted edge');
 
         const headerGroup = await toolPalette.content.toolGroupByHeaderText('Edges');
-        expect(await headerGroup.header()).toBe('Edges');
+        expect(await headerGroup.header()).toBe(integrationData[integration.type].edges);
 
         const headerElements = await headerGroup.items();
         expect(headerElements.length).toBe(2);
@@ -68,7 +84,7 @@ test.describe('The tool palette', () => {
         expect(await toolElement.tabIndexAttr()).toBe('6');
     });
 
-    test('should allow to access the toolbar items', async () => {
+    test('should allow to access the toolbar items', async ({ integration }) => {
         await toolPalette.waitForVisible();
 
         const deleteTool = await toolPalette.toolbar.deletionTool();
@@ -95,7 +111,7 @@ test.describe('The tool palette', () => {
 
         const groups = await toolPalette.content.toolGroups();
         expect(groups.length).toBe(1);
-        expect(await groups[0].header()).toBe('Nodes');
+        expect(await groups[0].header()).toBe(integrationData[integration.type].nodes);
 
         const elements0 = await groups[0].items();
         expect(elements0.length).toBe(1);

--- a/examples/workflow-test/tests/setup/vscode.setup.ts
+++ b/examples/workflow-test/tests/setup/vscode.setup.ts
@@ -1,0 +1,49 @@
+/********************************************************************************
+ * Copyright (c) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { IntegrationOptions, VSCodeIntegrationOptions, VSCodeStorage, expect, setup } from '@eclipse-glsp/glsp-playwright';
+
+setup.describe.configure({
+    mode: 'serial'
+});
+
+function assertVSCodeOptions(options?: IntegrationOptions): asserts options is VSCodeIntegrationOptions {
+    if (options === undefined || options.type !== 'VSCode') {
+        throw new Error('This setup can only be executed by VS Code integrations');
+    }
+}
+
+setup.describe('Setup VSCode', () => {
+    setup('Download VSCode', async ({ vscodeSetup, integrationOptions }) => {
+        assertVSCodeOptions(integrationOptions);
+        expect(vscodeSetup).toBeDefined();
+
+        const vscodeExecutablePath = await vscodeSetup!.downloadVSCode('stable');
+
+        await VSCodeStorage.write(integrationOptions.storagePath, { vscodeExecutablePath });
+    });
+
+    setup('Install extension', async ({ vscodeSetup, integrationOptions }) => {
+        assertVSCodeOptions(integrationOptions);
+        expect(vscodeSetup).toBeDefined();
+
+        const vscodeExecutablePath = (await VSCodeStorage.read(integrationOptions.storagePath)).vscodeExecutablePath;
+
+        await vscodeSetup!.install({
+            vscodeExecutablePath
+        });
+    });
+});

--- a/glsp.code-workspace
+++ b/glsp.code-workspace
@@ -11,6 +11,10 @@
         {
             "name": "glsp-theia-integration",
             "path": "../glsp-theia-integration"
+        },
+        {
+            "name": "glsp-vscode-integration",
+            "path": "../glsp-vscode-integration"
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "cd examples/workflow-test && yarn test",
     "test:standalone": "cd examples/workflow-test && yarn test:standalone",
     "test:theia": "cd examples/workflow-test && yarn test:theia",
+    "test:vscode": "cd examples/workflow-test && yarn test:vscode",
     "watch": "lerna run --parallel watch"
   },
   "devDependencies": {

--- a/packages/glsp-playwright/package.json
+++ b/packages/glsp-playwright/package.json
@@ -56,6 +56,7 @@
   },
   "devDependencies": {
     "@types/uuid": "^9.0.0",
+    "@vscode/test-electron": "^2.3.2",
     "concurrently": "^7.6.0",
     "tsc-alias": "^1.8.2"
   },

--- a/packages/glsp-playwright/src/integration/integration.base.ts
+++ b/packages/glsp-playwright/src/integration/integration.base.ts
@@ -37,6 +37,13 @@ export abstract class Integration {
     }
 
     /**
+     * Executed after the constructor to execute async commands
+     */
+    async initialize(): Promise<void> {
+        // Nothing to do
+    }
+
+    /**
      * Prepares the test execution. It runs the lifecycle methods
      * to reach the starting point of the test case by launching the GLSP-Client-Integration
      * (e.g., running the Electron Application, loading the page, opening Theia).

--- a/packages/glsp-playwright/src/integration/integration.type.ts
+++ b/packages/glsp-playwright/src/integration/integration.type.ts
@@ -16,11 +16,12 @@
 import type { PageIntegrationOptions } from './page';
 import type { StandaloneIntegrationOptions } from './standalone';
 import type { TheiaIntegrationOptions } from './theia';
+import type { VSCodeIntegrationOptions } from './vscode';
 
-export type IntegrationType = 'Page' | 'Standalone' | 'Theia';
+export type IntegrationType = 'Page' | 'Standalone' | 'Theia' | 'VSCode';
 
 export interface BaseIntegrationOptions {
     type: IntegrationType;
 }
 
-export type IntegrationOptions = PageIntegrationOptions | StandaloneIntegrationOptions | TheiaIntegrationOptions;
+export type IntegrationOptions = PageIntegrationOptions | StandaloneIntegrationOptions | TheiaIntegrationOptions | VSCodeIntegrationOptions;

--- a/packages/glsp-playwright/src/integration/theia/index.ts
+++ b/packages/glsp-playwright/src/integration/theia/index.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-
+export * from './po/theia-glsp-app.po';
 export * from './po/theia-glsp-editor.po';
 export * from './theia.integration';
 export * from './theia.options';

--- a/packages/glsp-playwright/src/integration/vscode/index.ts
+++ b/packages/glsp-playwright/src/integration/vscode/index.ts
@@ -13,6 +13,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+export * from './po/workbench-activitybar.po';
+export * from './po/workbench-view-explorer.po';
+export * from './po/workbench-view-extensions.po';
 export * from './vscode.integration';
 export * from './vscode.options';
 export * from './vscode.setup';

--- a/packages/glsp-playwright/src/integration/vscode/index.ts
+++ b/packages/glsp-playwright/src/integration/vscode/index.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,11 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-export * from './integration.base';
-export * from './integration.type';
-export * from './page';
-export * from './standalone';
-export * from './theia';
-export * from './vscode';
-export * from './wait.fixes';
-
+export * from './vscode.integration';
+export * from './vscode.options';
+export * from './vscode.setup';
+export * from './vscode.storage';

--- a/packages/glsp-playwright/src/integration/vscode/po/workbench-activitybar.po.ts
+++ b/packages/glsp-playwright/src/integration/vscode/po/workbench-activitybar.po.ts
@@ -1,0 +1,53 @@
+/********************************************************************************
+ * Copyright (c) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import type { Page } from '@playwright/test';
+import { VSCodeWorkbenchViewExplorer } from './workbench-view-explorer.po';
+import { VSCodeWorkbenchViewExtensions } from './workbench-view-extensions.po';
+
+/**
+ * Page Object for the [Workbench](https://code.visualstudio.com/api/extension-capabilities/extending-workbench).
+ */
+export class VSCodeWorkbenchActivitybar {
+    readonly locator;
+    readonly extensionsItemLocator;
+    readonly explorerItemLocator;
+
+    constructor(protected readonly page: Page, protected readonly selector = '[id="workbench.parts.activitybar"]') {
+        this.locator = this.page.locator(this.selector);
+        this.explorerItemLocator = this.locator.locator('.codicon-explorer-view-icon');
+        this.extensionsItemLocator = this.locator.locator('.codicon-extensions-view-icon');
+    }
+
+    async openExplorer(): Promise<VSCodeWorkbenchViewExplorer> {
+        const view = new VSCodeWorkbenchViewExplorer(this.page);
+
+        if (await view.locator.isHidden()) {
+            await this.explorerItemLocator.click();
+        }
+
+        return view;
+    }
+
+    async openExtensions(): Promise<VSCodeWorkbenchViewExtensions> {
+        const view = new VSCodeWorkbenchViewExtensions(this.page);
+
+        if (await view.locator.isHidden()) {
+            await this.extensionsItemLocator.click();
+        }
+
+        return view;
+    }
+}

--- a/packages/glsp-playwright/src/integration/vscode/po/workbench-view-explorer.po.ts
+++ b/packages/glsp-playwright/src/integration/vscode/po/workbench-view-explorer.po.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,11 +13,23 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-export * from './integration.base';
-export * from './integration.type';
-export * from './page';
-export * from './standalone';
-export * from './theia';
-export * from './vscode';
-export * from './wait.fixes';
+import type { Page } from '@playwright/test';
 
+/**
+ * Page Object for the file explorer view
+ * in the [Workbench](https://code.visualstudio.com/api/extension-capabilities/extending-workbench).
+ */
+export class VSCodeWorkbenchViewExplorer {
+    readonly locator;
+
+    protected readonly explorerFoldersViewLocator;
+
+    constructor(protected readonly page: Page, protected readonly selector = '[id="workbench.view.explorer"]') {
+        this.locator = this.page.locator(this.selector);
+        this.explorerFoldersViewLocator = this.locator.locator('.explorer-folders-view');
+    }
+
+    async openFile(path: string): Promise<void> {
+        return this.explorerFoldersViewLocator.locator(`[title$="${path}"]`).dblclick();
+    }
+}

--- a/packages/glsp-playwright/src/integration/vscode/po/workbench-view-extensions.po.ts
+++ b/packages/glsp-playwright/src/integration/vscode/po/workbench-view-extensions.po.ts
@@ -1,0 +1,40 @@
+/********************************************************************************
+ * Copyright (c) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import type { Locator, Page } from '@playwright/test';
+
+/**
+ * Page Object for the extensions view
+ * in the [Workbench](https://code.visualstudio.com/api/extension-capabilities/extending-workbench).
+ */
+export class VSCodeWorkbenchViewExtensions {
+    readonly locator;
+
+    constructor(protected readonly page: Page, protected readonly selector = '[id="workbench.view.extensions"]') {
+        this.locator = this.page.locator(this.selector);
+    }
+
+    extension(vsixId: string): Locator {
+        return this.locator.locator(`[data-extension-id="${vsixId}"]`);
+    }
+
+    async waitForStart(vsixId: string): Promise<void> {
+        const extension = this.extension(vsixId);
+
+        await extension.waitFor({
+            state: 'visible'
+        });
+    }
+}

--- a/packages/glsp-playwright/src/integration/vscode/vscode.integration.ts
+++ b/packages/glsp-playwright/src/integration/vscode/vscode.integration.ts
@@ -1,0 +1,185 @@
+/********************************************************************************
+ * Copyright (c) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import type { ElectronApplication, Locator, Page } from '@playwright/test';
+import { _electron as electron } from '@playwright/test';
+import { resolveCliArgsFromVSCodeExecutablePath } from '@vscode/test-electron';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as platformPath from 'path';
+import { v4 as uuidv4 } from 'uuid';
+import { SVGMetadataUtils } from '~/glsp';
+import { Integration } from '../integration.base';
+import type { IntegrationType } from '../integration.type';
+import { VSCodeWorkbenchActivitybar } from './po/workbench-activitybar.po';
+import type { VSCodeIntegrationOptions } from './vscode.options';
+import { VSCodeStorage } from './vscode.storage';
+
+export interface VSCodeRunConfig {
+    runId: string;
+    runFolder: string;
+    paths: RunPaths;
+}
+
+interface RunPaths {
+    extensionDir: string;
+    userDataDir: string;
+}
+
+/**
+ * The {@link VSCodeIntegration} provides the glue code for working
+ * with the VSCode version of the GLSP-Client.
+ *
+ * The integration will:
+ *
+ * - prefix the root selector to the correct frame, as webviews are used in VSCode
+ * - start the VSCode instance (i.e., Electron) with different run configurations
+ * - check if the extension is already installed
+ * - wait for the GLSP-Client
+ *
+ * **Note**
+ *
+ * Run configurations allow starting multiple Electron instances in parallel
+ * and the configuration will be saved in the temp folder.
+ */
+export class VSCodeIntegration extends Integration {
+    readonly type: IntegrationType = 'VSCode';
+    workbenchActivitybar: VSCodeWorkbenchActivitybar;
+
+    protected runConfig: VSCodeRunConfig;
+    protected electronApp: ElectronApplication;
+    protected storage: VSCodeStorage.Storage;
+
+    constructor(protected readonly options: VSCodeIntegrationOptions) {
+        super();
+    }
+
+    override async initialize(): Promise<void> {
+        const storagePath = this.options.storagePath;
+        const storage = await VSCodeStorage.read(storagePath);
+        if (VSCodeStorage.is(storage)) {
+            this.storage = storage;
+        } else {
+            throw Error(`Provided storage in "${storagePath}" was not a valid vscode storage. ${JSON.stringify(storage, null, 2)}`);
+        }
+    }
+
+    get page(): Page {
+        return this.electronApp.windows()[0];
+    }
+
+    override prefixRootSelector(selector: string): Locator {
+        return this.page.frameLocator('iframe').frameLocator('iframe').locator(selector);
+    }
+
+    override async close(): Promise<void> {
+        await this.electronApp.close();
+        await fs.rm(this.runConfig.runFolder, { recursive: true, force: true });
+    }
+
+    protected override async beforeLaunch(): Promise<void> {
+        this.runConfig = await this.createRunConfiguration(this.options, this.storage);
+    }
+
+    protected override async launch(): Promise<void> {
+        this.electronApp = await electron.launch({
+            executablePath: this.storage.vscodeExecutablePath,
+            args: [
+                ...VSCodeIntegrationUtils.pathArgs(this.runConfig),
+                '--new-window',
+                '--inspect',
+                '--skip-release-notes',
+                '--skip-welcome',
+                '--disable-telemetry',
+                '--no-cached-data',
+                '--disable-updates',
+                '--disable-keytar',
+                '--disable-crash-reporter',
+                '--disable-workspace-trust',
+                '--disable-gpu',
+                this.options.workspace
+            ]
+        });
+
+        this.electronApp.on('window', async page => {
+            page.on('pageerror', error => {
+                console.error(error);
+            });
+
+            page.on('console', msg => {
+                // console.log(msg.text());
+            });
+        });
+    }
+
+    protected override async afterLaunch(): Promise<void> {
+        const ePage = await this.electronApp.firstWindow();
+        await ePage.waitForLoadState('domcontentloaded');
+
+        this.workbenchActivitybar = new VSCodeWorkbenchActivitybar(ePage);
+
+        await this.waitForReady();
+
+        if (this.options.file) {
+            await this.navigateToFile(this.options.file);
+        }
+    }
+
+    protected async createRunConfiguration(options: VSCodeIntegrationOptions, storage: VSCodeStorage.Storage): Promise<VSCodeRunConfig> {
+        const runId = uuidv4();
+
+        const [, ...defaultArgs] = resolveCliArgsFromVSCodeExecutablePath(storage.vscodeExecutablePath);
+        const runFolder = await fs.mkdtemp(platformPath.join(os.tmpdir(), 'glsp-playwright-run-'));
+        const extensionArg = defaultArgs[0].split(/=(.*)/s);
+
+        return {
+            runId,
+            runFolder,
+            paths: {
+                extensionDir: extensionArg[1],
+                userDataDir: 'user-data'
+            }
+        };
+    }
+
+    protected async waitForReady(): Promise<void> {
+        const extensionsView = await this.workbenchActivitybar.openExtensions();
+        await extensionsView.waitForStart(this.options.vsixId);
+        await this.workbenchActivitybar.openExplorer();
+    }
+
+    protected async navigateToFile(file: string): Promise<void> {
+        const explorerView = await this.workbenchActivitybar.openExplorer();
+        await explorerView.openFile(file);
+        await this.assertMetadataAPI();
+        await this.prefixRootSelector(`${SVGMetadataUtils.typeAttrOf('graph')} svg.sprotty-graph > g`).waitFor({ state: 'visible' });
+    }
+}
+
+export namespace VSCodeIntegrationUtils {
+    export function fullPath(config: VSCodeRunConfig, path: keyof RunPaths): string {
+        const configPath = config.paths[path];
+
+        if (configPath.startsWith('/')) {
+            return configPath;
+        }
+
+        return `${config.runFolder}/${configPath}`;
+    }
+
+    export function pathArgs(config: VSCodeRunConfig): string[] {
+        return [`--extensions-dir=${fullPath(config, 'extensionDir')}`, `--user-data-dir=${fullPath(config, 'userDataDir')}`];
+    }
+}

--- a/packages/glsp-playwright/src/integration/vscode/vscode.integration.ts
+++ b/packages/glsp-playwright/src/integration/vscode/vscode.integration.ts
@@ -119,7 +119,9 @@ export class VSCodeIntegration extends Integration {
             });
 
             page.on('console', msg => {
-                // console.log(msg.text());
+                if (this.options.isConsoleLogEnabled) {
+                    console.log(msg.text());
+                }
             });
         });
     }

--- a/packages/glsp-playwright/src/integration/vscode/vscode.options.ts
+++ b/packages/glsp-playwright/src/integration/vscode/vscode.options.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,11 +13,19 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-export * from './integration.base';
-export * from './integration.type';
-export * from './page';
-export * from './standalone';
-export * from './theia';
-export * from './vscode';
-export * from './wait.fixes';
+import type { BaseIntegrationOptions, IntegrationOptions } from '../integration.type';
 
+export interface VSCodeIntegrationOptions extends BaseIntegrationOptions {
+    type: 'VSCode';
+    workspace: string;
+    vsixId: string;
+    vsixPath: string;
+    storagePath: string;
+    file?: string;
+}
+
+export namespace VSCodeIntegrationOptions {
+    export function is(options?: IntegrationOptions): options is VSCodeIntegrationOptions {
+        return options?.type === 'VSCode';
+    }
+}

--- a/packages/glsp-playwright/src/integration/vscode/vscode.options.ts
+++ b/packages/glsp-playwright/src/integration/vscode/vscode.options.ts
@@ -22,6 +22,11 @@ export interface VSCodeIntegrationOptions extends BaseIntegrationOptions {
     vsixPath: string;
     storagePath: string;
     file?: string;
+    /*
+     * Logs the content of the Electron Application to the console.
+     * Disabled by default.
+     */
+    isConsoleLogEnabled?: boolean;
 }
 
 export namespace VSCodeIntegrationOptions {

--- a/packages/glsp-playwright/src/integration/vscode/vscode.setup.ts
+++ b/packages/glsp-playwright/src/integration/vscode/vscode.setup.ts
@@ -1,0 +1,143 @@
+/********************************************************************************
+ * Copyright (c) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import {
+    ConsoleReporter as VSCodeDownloadConsoleReporter,
+    downloadAndUnzipVSCode,
+    resolveCliArgsFromVSCodeExecutablePath
+} from '@vscode/test-electron';
+import * as cp from 'child_process';
+import { constants } from 'fs';
+import * as fs from 'fs/promises';
+import { VSCodeIntegrationOptions } from './vscode.options';
+
+export interface VSCodeExtensionFile {
+    identifier: {
+        id: string;
+    };
+    version: string;
+    metadata: {
+        installedTimestamp: number;
+    };
+}
+
+export interface VSCodeSetupOptions {
+    enableLogging: boolean;
+}
+
+/**
+ * The {@link VSCodeSetup} prepares the environment to run VSCode tests.
+ *
+ * It provides functionality to:
+ *
+ * - download the newest VSCode instance with unpacking it in the folder `.vscode-test`
+ * - install extensions
+ */
+export class VSCodeSetup {
+    protected readonly vscodeDownloadReporter = new VSCodeDownloadConsoleReporter(true);
+
+    constructor(
+        protected readonly integrationOptions: VSCodeIntegrationOptions,
+        protected readonly setupOptions: VSCodeSetupOptions = {
+            enableLogging: false
+        }
+    ) {}
+
+    async downloadVSCode(version: string): Promise<string> {
+        return downloadAndUnzipVSCode(version, undefined, {
+            report: report => {
+                if (this.setupOptions.enableLogging) {
+                    this.vscodeDownloadReporter.report(report);
+                }
+            },
+            error: error => {
+                this.vscodeDownloadReporter.error(error);
+            }
+        });
+    }
+
+    /**
+     * If the extension will be installed depends on different factors:
+     *
+     * - If the extension is not installed, it will install it.
+     * - If the extension is already installed, then the installation will be skipped.
+     *
+     * Moreover, the following checks are done:
+     *
+     * - If the create timestamp of the vsix file is newer than the installation time of the extension,
+     * then it will be reinstalled.
+     * - If any error occurs, it will proceed with a clean install.
+     */
+    async install(options: { vscodeExecutablePath: string }): Promise<void> {
+        const [cli, ...defaultArgs] = resolveCliArgsFromVSCodeExecutablePath(options.vscodeExecutablePath);
+
+        const extensionArg = defaultArgs[0].split(/=(.*)/s);
+        const extensionDir = extensionArg[1];
+
+        try {
+            const extensionsFile = `${extensionDir}/extensions.json`;
+            await fs.access(extensionsFile, constants.R_OK);
+
+            const installedExtensions = JSON.parse(await fs.readFile(extensionsFile, 'utf8')) as VSCodeExtensionFile[];
+            const entry = installedExtensions.find(e => e.identifier.id === this.integrationOptions.vsixId);
+
+            if (entry === undefined) {
+                this.installExtension(cli, extensionArg, this.integrationOptions.vsixPath);
+                this.log('[Extension] Extension installed');
+            } else {
+                const stat = await fs.stat(this.integrationOptions.vsixPath);
+                if (entry.metadata.installedTimestamp < stat.birthtimeMs) {
+                    this.log(
+                        '[Extension] Older install detected.',
+                        new Date(entry.metadata.installedTimestamp).toISOString(),
+                        new Date(stat.birthtimeMs).toISOString()
+                    );
+                    this.deleteExtension(cli, extensionArg, this.integrationOptions.vsixId);
+                    this.installExtension(cli, extensionArg, this.integrationOptions.vsixPath);
+                    this.log('[Extension] Extension installed');
+                } else {
+                    this.log('[Extension] Extension already installed. Skipping install');
+                }
+            }
+        } catch (ex) {
+            this.log('[Extension] Proceed with clean install.');
+            this.deleteExtension(cli, extensionArg, this.integrationOptions.vsixId);
+            this.installExtension(cli, extensionArg, this.integrationOptions.vsixPath);
+            this.log('[Extension] Extension installed');
+        }
+    }
+
+    protected log(message: string, ...params: any[]): void {
+        if (this.setupOptions.enableLogging) {
+            console.log(message, ...params);
+        }
+    }
+
+    protected deleteExtension(cli: string, args: string[], vsixId: string): void {
+        this.log('[Extension] Delete:', vsixId);
+        cp.spawnSync(cli, [...args, '--uninstall-extension', vsixId], {
+            encoding: 'utf-8',
+            stdio: 'inherit'
+        });
+    }
+
+    protected installExtension(cli: string, args: string[], vsixPath: string): void {
+        this.log('[Extension] Install:', vsixPath);
+        cp.spawnSync(cli, [...args, '--install-extension', vsixPath], {
+            encoding: 'utf-8',
+            stdio: 'inherit'
+        });
+    }
+}

--- a/packages/glsp-playwright/src/integration/vscode/vscode.storage.ts
+++ b/packages/glsp-playwright/src/integration/vscode/vscode.storage.ts
@@ -1,0 +1,42 @@
+/********************************************************************************
+ * Copyright (c) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { promises as fsp } from 'fs';
+
+/**
+ * Util namespace for managing the shared storage for the VSCode environment.
+ */
+export namespace VSCodeStorage {
+    export interface Storage {
+        vscodeExecutablePath: string;
+    }
+
+    export function write(path: string, storage: Storage): Promise<void> {
+        return fsp.writeFile(path, JSON.stringify(storage, null, 2));
+    }
+
+    export async function read(path: string): Promise<Storage> {
+        const content = await fsp.readFile(path, 'utf8');
+        return JSON.parse(content);
+    }
+
+    export function is(data: any): data is Storage {
+        return existsKey(data, 'vscodeExecutablePath');
+    }
+}
+
+function existsKey(data: any, key: keyof VSCodeStorage.Storage): boolean {
+    return data[key] !== undefined;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1591,6 +1591,11 @@
     "@playwright/test" "^1.32.1"
     fs-extra "^9.0.8"
 
+"@tootallnate/once@1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
+  integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
@@ -1778,6 +1783,16 @@
   dependencies:
     "@typescript-eslint/types" "5.51.0"
     eslint-visitor-keys "^3.3.0"
+
+"@vscode/test-electron@^2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@vscode/test-electron/-/test-electron-2.3.2.tgz#25db8d1a94e8274c27015cf806ae8b180c83545b"
+  integrity sha512-CRfQIs5Wi5Ok5SUCC3PTvRRXa74LD43cSXHC8EuNlmHHEPaJa/AGrv76brcA1hVSxrdja9tiYwp95Lq8kwY0tw==
+  dependencies:
+    http-proxy-agent "^4.0.1"
+    https-proxy-agent "^5.0.0"
+    jszip "^3.10.1"
+    semver "^7.3.8"
 
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
@@ -3815,6 +3830,15 @@ http-cache-semantics@^4.1.0:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
   integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
 
+http-proxy-agent@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
+  integrity sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==
+  dependencies:
+    "@tootallnate/once" "1"
+    agent-base "6"
+    debug "4"
+
 http-proxy-agent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
@@ -3879,6 +3903,11 @@ ignore@^5.0.4, ignore@^5.2.0:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
+
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
@@ -4399,6 +4428,16 @@ jsonparse@^1.2.0, jsonparse@^1.3.1:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
+jszip@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
+  integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==
+  dependencies:
+    lie "~3.3.0"
+    pako "~1.0.2"
+    readable-stream "~2.3.6"
+    setimmediate "^1.0.5"
+
 just-diff-apply@^5.2.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/just-diff-apply/-/just-diff-apply-5.5.0.tgz#771c2ca9fa69f3d2b54e7c3f5c1dfcbcc47f9f0f"
@@ -4478,6 +4517,13 @@ libnpmpublish@^6.0.4:
     npm-registry-fetch "^13.0.0"
     semver "^7.3.7"
     ssri "^9.0.0"
+
+lie@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
+  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
+  dependencies:
+    immediate "~3.0.5"
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
@@ -5463,6 +5509,11 @@ pacote@^13.0.3, pacote@^13.6.1:
     ssri "^9.0.0"
     tar "^6.1.11"
 
+pako@~1.0.2:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -6005,6 +6056,13 @@ semver@^7.0.0, semver@^7.1.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.3.8:
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.1.tgz#c90c4d631cf74720e46b21c1d37ea07edfab91ec"
+  integrity sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==
+  dependencies:
+    lru-cache "^6.0.0"
+
 serialize-javascript@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
@@ -6016,6 +6074,11 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
+
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
 
 shallow-clone@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
This PR is part of my diploma research conducted at the [Model Engineering lab](https://me.big.tuwien.ac.at/) of TU Wien in the [Business Informatics Group](https://www.big.tuwien.ac.at/).

---

- Necessary **Page Objects** for VSCode are added
- Necessary **Integration** for VSCode is added 
- **Setup logic** for setting the environment is provided
  - Including downloading VSCode and installing extensions 
- Introduce a way to parameterize test data based on the integration used

# Disclaimer:

The current GLSP-VSCode Integration does not have support for creating `vsix` files.

The following `package.json` can be used to create the `vsix` file. Afterward, run `yarn package`.

```json
{
  ...
  "main": "./lib/workflow-extension",
  ...
   "scripts": {
    ... 
    "esbuild": "npm run esbuild-base --sourcemap",
    "esbuild-base": "esbuild ./src/workflow-extension.ts --bundle --outfile=lib/workflow-extension.js --external:vscode --format=cjs --platform=node",
    "package": "yarn clean && vsce package --yarn",
    "vscode:prepublish": "npm run esbuild-base",
  },
  ...
  "devDependencies": {
    ...
    "@vscode/vsce": "^2.19.0",
    "esbuild": "^0.17.19"
  },
  ...
}
``` 