### PR TITLE
Remove GLSPGraph implementation detail and provide debugging information

### DIFF
--- a/examples/workflow-test/README.md
+++ b/examples/workflow-test/README.md
@@ -107,6 +107,27 @@ Use the `Watch All` task to rebuild the project automatically after doing change
 
 > Note: The test files will be also rebuild.
 
+## Debugging
+
+1. Read the [Playwright Debug Documentation](https://playwright.dev/docs/debug).
+2. Install the VSCode Playwright Extension.
+
+### Live Debugging
+
+-   Read the [Live Debugging Documentation](https://playwright.dev/docs/debug#live-debugging)
+-   You can get the locator of a specific page object or a `GLSPLocator` by using the `.locate()` method:
+
+```ts
+const locator = task.locate();
+```
+
+-   Click on the locator variable to highlight it within the browser
+
+### Extractors
+
+Using the powerful debugger coming with `Playwright` is the recommended way to debug the test cases.
+Still, to provide more information, we offer util functions to extract additional context information. See the [debug tests](./tests/core/debug.standalone.spec.ts) for instructions on how to use them.
+
 ## More information
 
 For more information, please visit the [Eclipse GLSP Umbrella repository](https://github.com/eclipse-glsp/glsp) and the [Eclipse GLSP Website](https://www.eclipse.org/glsp/).

--- a/examples/workflow-test/configs/project.config.ts
+++ b/examples/workflow-test/configs/project.config.ts
@@ -71,6 +71,7 @@ export function createTheiaProject(): Project<PlaywrightTestOptions & GLSPPlaywr
         {
             name: 'theia',
             testMatch: ['**/*.spec.js'],
+            testIgnore: ['**/*.standalone.spec.js'],
             use: {
                 ...projectDevices,
                 baseURL: theiaIntegrationOptions.url,
@@ -109,6 +110,7 @@ export function createVSCodeProject(): Project<PlaywrightTestOptions & GLSPPlayw
         {
             name: 'vscode',
             testMatch: ['**/*.spec.js'],
+            testIgnore: ['**/*.standalone.spec.js'],
             dependencies: ['vscode-setup'],
             use: {
                 integrationOptions: vscodeIntegrationOptions

--- a/examples/workflow-test/tests/core/debug.standalone.spec.ts
+++ b/examples/workflow-test/tests/core/debug.standalone.spec.ts
@@ -1,0 +1,96 @@
+/********************************************************************************
+ * Copyright (c) 2024 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+/* eslint-disable max-len */
+
+import { expect, extractDebugInformationOfGLSPLocator, extractMetaTree, test } from '@eclipse-glsp/glsp-playwright/';
+import { WorkflowApp } from '../../src/app/workflow-app';
+import { TaskManual } from '../../src/graph/elements/task-manual.po';
+import { WorkflowGraph } from '../../src/graph/workflow.graph';
+
+const taskSelector = '[id$="task0"]';
+const expectedElementMetadata = {
+    id: 'sprotty_task0',
+    type: 'task:manual',
+    parent: 'sprotty_sprotty',
+    children: [
+        {
+            id: 'sprotty_task0_icon',
+            type: 'icon',
+            parent: 'sprotty_task0',
+            children: [],
+            html: ''
+        },
+        {
+            id: 'sprotty_task0_classname',
+            type: 'label:heading',
+            parent: 'sprotty_task0',
+            children: [],
+            html: 'Push'
+        }
+    ],
+    html: 'Push'
+};
+const expectedGLSPLocatorData = [
+    {
+        locator:
+            "locator('body').locator('div.sprotty:not(.sprotty-hidden)').locator('[data-svg-metadata-type=\"graph\"]').locator('[id$=\"task0\"]').and(locator('body').locator('div.sprotty:not(.sprotty-hidden)').locator('[data-svg-metadata-type=\"graph\"]').locator('[data-svg-metadata-type=\"task:manual\"]'))",
+        children: [
+            '<g id="sprotty_task0" transform="translate(70, 140)" data-svg-metadata-type="task:manual" data-svg-metadata-parent-id="sprotty_sprotty" class="node task manual">...</g>'
+        ]
+    },
+    {
+        locator: "locator('body').locator('div.sprotty:not(.sprotty-hidden)')",
+        children: ['<div id="sprotty" class="sprotty">...</div>']
+    },
+    { locator: "locator('body')", children: ['<body>...</body>'] }
+];
+
+test.describe('The debug functions', () => {
+    let app: WorkflowApp;
+    let graph: WorkflowGraph;
+
+    test.beforeEach(async ({ integration }) => {
+        app = new WorkflowApp({
+            type: 'integration',
+            integration
+        });
+        graph = app.graph;
+    });
+
+    /**
+     * It is possible to extract all the accessible SVG metadata of a locator as a tree structure.
+     */
+    test('should allow to extract the metadata of a locator', async () => {
+        const node = await graph.getNodeBySelector(taskSelector, TaskManual);
+
+        const metadata = await extractMetaTree(node.locate());
+        expect(metadata).toMatchObject(expectedElementMetadata);
+    });
+
+    /**
+     * It is possible to retrieve all the located HTML elements of a GLSPLocator and it's ascendants.
+     */
+    test('should allow to extract debug information of a GLSPLocator', async () => {
+        const node = await graph.getNodeBySelector(taskSelector, TaskManual);
+
+        const extracted = await extractDebugInformationOfGLSPLocator(node.locator);
+        expect(extracted).toMatchObject(expectedGLSPLocatorData);
+    });
+
+    test.afterEach(async ({ integration }) => {
+        await integration?.close();
+    });
+});

--- a/packages/glsp-playwright/src/debug/index.ts
+++ b/packages/glsp-playwright/src/debug/index.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2024 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,10 +14,4 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export * from './debug';
-export * from './extension';
-export * from './glsp';
-export * from './integration';
-export * from './remote';
-export * from './test';
-export * from './types';
+export * from './utils';

--- a/packages/glsp-playwright/src/glsp/app/app.po.ts
+++ b/packages/glsp-playwright/src/glsp/app/app.po.ts
@@ -52,7 +52,7 @@ export type GLSPAppOptions = GLSPPageOptions | GLSPIntegrationOptions;
 /**
  * The central piece of the **GLSP-Playwright** framework.
  * The {@link GLSPApp} is the entry point into the framework and provides all the necessary
- * page objects to interact with the GLSP-Client.
+ * page objects to interact with the GLSP-Client. You can extend {@link GLSPApp} and provide your own customizations.
  *
  * **Usage**
  *
@@ -79,7 +79,7 @@ export type GLSPAppOptions = GLSPPageOptions | GLSPIntegrationOptions;
  * ```
  */
 export class GLSPApp {
-    readonly sprottySelector = 'div.sprotty';
+    readonly sprottySelector = 'div.sprotty:not(.sprotty-hidden)';
 
     rootLocator: GLSPLocator;
     locator: GLSPLocator;

--- a/packages/glsp-playwright/src/glsp/graph/elements/element.ts
+++ b/packages/glsp-playwright/src/glsp/graph/elements/element.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { Locator } from '@playwright/test';
-import { extractMetaTree } from '~/debugger/extractor';
+import { extractMetaTree } from '~/debug';
 import { GLSPLocator, Locateable } from '~/remote';
 import type { ConstructorT } from '~/types/constructor';
 import { definedGLSPAttr } from '~/utils/ts.utils';

--- a/packages/glsp-playwright/src/glsp/graph/graph.po.ts
+++ b/packages/glsp-playwright/src/glsp/graph/graph.po.ts
@@ -43,7 +43,7 @@ export interface GLSPGraphOptions {
  */
 export class GLSPGraph extends Locateable {
     static locate(app: GLSPApp): GLSPLocator {
-        return app.locator.child(SVGMetadataUtils.typeAttrOf('graph')).child('svg.sprotty-graph');
+        return app.locator.child(SVGMetadataUtils.typeAttrOf('graph'));
     }
 
     constructor(protected readonly options: GLSPGraphOptions) {

--- a/packages/glsp-playwright/src/remote/locator.ts
+++ b/packages/glsp-playwright/src/remote/locator.ts
@@ -22,7 +22,11 @@ import type { GLSPApp } from '~/glsp/app';
  *
  */
 export class GLSPLocator {
-    constructor(protected readonly locator: Locator, public readonly app: GLSPApp, public readonly parent?: GLSPLocator) {}
+    constructor(
+        protected readonly locator: Locator,
+        public readonly app: GLSPApp,
+        public readonly parent?: GLSPLocator
+    ) {}
 
     get page(): Page {
         return this.app.page;
@@ -38,11 +42,12 @@ export class GLSPLocator {
     /**
      * Appends the provided selector to the current {@link GLSPLocator} as child.
      *
-     * @param selector Selector of the element
+     * @param selectorOrLocator Selector or locator of the element
+     * @param options Options for the locator
      * @returns New {@link GLSPLocator} with the provided selector as child
      */
-    child(selector: string): GLSPLocator {
-        return new GLSPLocator(this.locator.locator(selector), this.app, this);
+    child(selectorOrLocator: string | Locator, options?: Parameters<Locator['locator']>[1]): GLSPLocator {
+        return new GLSPLocator(this.locator.locator(selectorOrLocator, options), this.app, this);
     }
 
     /**


### PR DESCRIPTION
#### What it does

- Removes the implementation detail of the GLSPGraph locator
- Introduces examples on how to retrieve debug information

#### How to test

Execute the test file: `examples/workflow-test/tests/core/debug.standalone.spec.ts` with Playwright.

#### Follow-ups

#### Changelog

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)

Closes https://github.com/eclipse-glsp/glsp/issues/1263
