### PR TITLE
Fix java server differences

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
     env:
       THEIA_URL: 'http://localhost:3000'
       VSCODE_VSIX_ID: 'eclipse-glsp.workflow-vscode-example'
+      GLSP_SERVER_TYPE: 'node'
       GLSP_SERVER_DEBUG: 'true'
       GLSP_SERVER_PORT: '8081'
       GLSP_SERVER_PLAYWRIGHT_MANAGED: 'true'
@@ -87,13 +88,13 @@ jobs:
           path: examples/workflow-test/playwright-report/
 
   playwright-java:
-    if: false
     name: Playwright Tests (Java server)
     timeout-minutes: 120
     runs-on: ubuntu-latest
     env:
       THEIA_URL: 'http://localhost:3000'
       VSCODE_VSIX_ID: 'eclipse-glsp.workflow-vscode-example'
+      GLSP_SERVER_TYPE: 'java'
       GLSP_SERVER_DEBUG: 'true'
       GLSP_SERVER_PORT: '8081'
       GLSP_SERVER_PLAYWRIGHT_MANAGED: 'true'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       THEIA_URL: 'http://localhost:3000'
       VSCODE_VSIX_ID: 'eclipse-glsp.workflow-vscode-example'
+      GLSP_SERVER_TYPE: 'node'
       GLSP_SERVER_DEBUG: 'true'
       GLSP_SERVER_PORT: '8081'
       GLSP_SERVER_PLAYWRIGHT_MANAGED: 'true'

--- a/examples/workflow-test/.env.example
+++ b/examples/workflow-test/.env.example
@@ -2,6 +2,7 @@ GLSP_SERVER_DEBUG="true" # For Theia and VSCode instances to connect to an exter
 GLSP_SERVER_PORT="8081"
 GLSP_SERVER_PLAYWRIGHT_MANAGED="true" # To allow Playwright to manage/start the server
 GLSP_WEBSOCKET_PATH="workflow"
+GLSP_SERVER_TYPE="node" # To use the node server
 
 # Configurations
 STANDALONE_URL="file:///.../repositories/glsp-client/examples/workflow-standalone/app/diagram.html"

--- a/examples/workflow-test/src/server/index.ts
+++ b/examples/workflow-test/src/server/index.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2024 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,12 +14,5 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export * from './debug';
-export * from './extension';
-export * from './glsp';
-export * from './glsp-server';
-export * from './integration';
-export * from './remote';
-export * from './test';
-export * from './types';
-export * from './utils';
+export const GLSP_SERVER_TYPE_NODE = 'node';
+export const GLSP_SERVER_TYPE_JAVA = 'java';

--- a/examples/workflow-test/tests/features/command-palette/command-palette.spec.ts
+++ b/examples/workflow-test/tests/features/command-palette/command-palette.spec.ts
@@ -14,11 +14,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { GLSPGlobalCommandPalette, expect, test } from '@eclipse-glsp/glsp-playwright/';
+import { GLSPServer } from '@eclipse-glsp/glsp-playwright/src/glsp-server';
+import { ServerVariable } from '@eclipse-glsp/glsp-playwright/src/test/dynamic-variable';
 import { WorkflowApp } from '../../../src/app/workflow-app';
 import { Edge } from '../../../src/graph/elements/edge.po';
 import { TaskAutomated } from '../../../src/graph/elements/task-automated.po';
 import { TaskManual } from '../../../src/graph/elements/task-manual.po';
 import { WorkflowGraph } from '../../../src/graph/workflow.graph';
+import { GLSP_SERVER_TYPE_JAVA, GLSP_SERVER_TYPE_NODE } from '../../../src/server';
 
 const element1Label = 'Push';
 const element2Label = 'ChkWt';
@@ -27,14 +30,16 @@ test.describe('The command palette', () => {
     let app: WorkflowApp;
     let graph: WorkflowGraph;
     let globalCommandPalette: GLSPGlobalCommandPalette;
+    let server: GLSPServer;
 
-    test.beforeEach(async ({ integration }) => {
+    test.beforeEach(async ({ integration, glspServer }) => {
         app = new WorkflowApp({
             type: 'integration',
             integration
         });
         graph = app.graph;
         globalCommandPalette = app.globalCommandPalette;
+        server = glspServer;
     });
 
     test.describe('in the global context', () => {
@@ -45,23 +50,43 @@ test.describe('The command palette', () => {
             expect(await globalCommandPalette.isVisible()).toBeTruthy();
 
             const suggestions = await globalCommandPalette.suggestions();
-            const expectedSuggestions = [
-                'Create Manual Task',
-                'Create Category',
-                'Create Automated Task',
-                'Create Merge Node',
-                'Create Decision Node',
-                'Delete All',
-                'Reveal Push',
-                'Reveal ChkWt',
-                'Reveal WtOK',
-                'Reveal RflWt',
-                'Reveal Brew',
-                'Reveal ChkTp',
-                'Reveal KeepTp',
-                'Reveal PreHeat'
-            ];
-            expect(suggestions.sort()).toEqual(expectedSuggestions.sort());
+            const expectedSuggestions = new ServerVariable({
+                server,
+                value: {
+                    [GLSP_SERVER_TYPE_NODE]: [
+                        'Create Manual Task',
+                        'Create Category',
+                        'Create Automated Task',
+                        'Create Merge Node',
+                        'Create Decision Node',
+                        'Delete All',
+                        'Reveal Push',
+                        'Reveal ChkWt',
+                        'Reveal WtOK',
+                        'Reveal RflWt',
+                        'Reveal Brew',
+                        'Reveal ChkTp',
+                        'Reveal KeepTp',
+                        'Reveal PreHeat'
+                    ],
+                    [GLSP_SERVER_TYPE_JAVA]: [
+                        'Create Manual Task',
+                        'Create Category',
+                        'Create Automated Task',
+                        'Create Merge Node',
+                        'Create Decision Node',
+                        'Reveal Push',
+                        'Reveal ChkWt',
+                        'Reveal WtOK',
+                        'Reveal RflWt',
+                        'Reveal Brew',
+                        'Reveal ChkTp',
+                        'Reveal KeepTp',
+                        'Reveal PreHeat'
+                    ]
+                }
+            });
+            expect(suggestions.sort()).toEqual(expectedSuggestions.get().sort());
 
             await globalCommandPalette.search('Create');
             const createSuggestions = await globalCommandPalette.suggestions();

--- a/examples/workflow-test/tests/features/hover/popup.spec.ts
+++ b/examples/workflow-test/tests/features/hover/popup.spec.ts
@@ -76,7 +76,7 @@ test.describe('The popup', () => {
     test.beforeEach(async ({ integration, glspServer }) => {
         app = new WorkflowApp({
             type: 'integration',
-            integration: integration
+            integration
         });
         graph = app.graph;
         expectedManualPopupText.setServer(glspServer);

--- a/examples/workflow-test/tests/features/validation/marker-navigator.spec.ts
+++ b/examples/workflow-test/tests/features/validation/marker-navigator.spec.ts
@@ -13,15 +13,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import {
-    MarkerNavigator,
-    StandaloneMarkerNavigator,
-    TheiaMarkerNavigator,
-    createParameterizedIntegrationData,
-    expect,
-    test
-} from '@eclipse-glsp/glsp-playwright/';
+import { MarkerNavigator, StandaloneMarkerNavigator, TheiaMarkerNavigator, expect, test } from '@eclipse-glsp/glsp-playwright/';
 import { skipIntegration } from '@eclipse-glsp/glsp-playwright/src/test';
+import { IntegrationVariable } from '@eclipse-glsp/glsp-playwright/src/test/dynamic-variable';
 import { WorkflowApp } from '../../../src/app/workflow-app';
 import { TaskAutomated } from '../../../src/graph/elements/task-automated.po';
 import { WorkflowGraph } from '../../../src/graph/workflow.graph';
@@ -47,24 +41,24 @@ test.describe('The marker navigator', () => {
             integration
         });
         graph = app.graph;
-        navigator = createParameterizedIntegrationData<() => MarkerNavigator>({
-            default: () => {
-                throw new Error('Integration not supported for marker navigator');
+        const navigatorProvider = new IntegrationVariable({
+            value: {
+                Standalone: new StandaloneMarkerNavigator(app),
+                Theia: new TheiaMarkerNavigator(app)
             },
-            override: {
-                Standalone: () => new StandaloneMarkerNavigator(app),
-                Theia: () => new TheiaMarkerNavigator(app)
-            }
-        })[integration.type]();
+            integration
+        });
+
+        navigator = navigatorProvider.get();
 
         await navigator.trigger();
     });
 
     // VSCode has no support for navigation
-    test.skip(({ integrationOptions }) => skipIntegration(integrationOptions, 'VSCode'));
+    test.skip(({ integrationOptions }) => skipIntegration(integrationOptions, 'VSCode'), 'Not supported');
 
     test('should navigate to the first element', async ({ integrationOptions }) => {
-        test.skip(skipIntegration(integrationOptions, 'VSCode'));
+        test.skip(skipIntegration(integrationOptions, 'VSCode'), 'Not supported');
 
         await navigator.navigateForward();
         await app.page.pause();

--- a/examples/workflow-test/tests/features/validation/marker-navigator.spec.ts
+++ b/examples/workflow-test/tests/features/validation/marker-navigator.spec.ts
@@ -41,7 +41,7 @@ test.describe('The marker navigator', () => {
             integration
         });
         graph = app.graph;
-        const navigatorProvider = new IntegrationVariable({
+        const navigatorProvider = new IntegrationVariable<MarkerNavigator>({
             value: {
                 Standalone: new StandaloneMarkerNavigator(app),
                 Theia: new TheiaMarkerNavigator(app)

--- a/packages/glsp-playwright/src/glsp-server/index.ts
+++ b/packages/glsp-playwright/src/glsp-server/index.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2024 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,12 +14,4 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export * from './debug';
-export * from './extension';
-export * from './glsp';
-export * from './glsp-server';
-export * from './integration';
-export * from './remote';
-export * from './test';
-export * from './types';
-export * from './utils';
+export * from './server';

--- a/packages/glsp-playwright/src/glsp-server/server.ts
+++ b/packages/glsp-playwright/src/glsp-server/server.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023 Business Informatics Group (TU Wien) and others.
+ * Copyright (c) 2024 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,12 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export * from './debug';
-export * from './extension';
-export * from './glsp';
-export * from './glsp-server';
-export * from './integration';
-export * from './remote';
-export * from './test';
-export * from './types';
-export * from './utils';
+export interface GLSPServer {
+    type: string;
+}
+
+export const GLSP_SERVER_TYPE_UNKNWON = 'unknown';

--- a/packages/glsp-playwright/src/test.ts
+++ b/packages/glsp-playwright/src/test.ts
@@ -25,6 +25,7 @@ import {
     VSCodeIntegration,
     VSCodeSetup
 } from '~/integration';
+import { GLSP_SERVER_TYPE_UNKNWON, GLSPServer } from './glsp-server';
 
 /**
  * GLSP-Playwright specific options
@@ -56,6 +57,7 @@ export interface GLSPPlaywrightFixtures {
      * ```
      */
     integration: Integration;
+    glspServer: GLSPServer;
     vscodeSetup?: VSCodeSetup;
 }
 
@@ -68,6 +70,14 @@ export const test = base.extend<GLSPPlaywrightOptions & GLSPPlaywrightFixtures>(
         } else {
             use(undefined);
         }
+    },
+
+    glspServer: async ({ page }, use) => {
+        const server: GLSPServer = {
+            type: process.env.GLSP_SERVER_TYPE ?? GLSP_SERVER_TYPE_UNKNWON
+        };
+
+        await use(server);
     },
 
     integration: async ({ playwright, browser, page, integrationOptions }, use) => {
@@ -110,21 +120,6 @@ export const test = base.extend<GLSPPlaywrightOptions & GLSPPlaywrightFixtures>(
         }
     }
 });
-
-// https://playwright.dev/docs/test-parameterize
-
-export type ParameterizedIntegrationData<T> = Record<IntegrationType, T>;
-export function createParameterizedIntegrationData<T>(options: {
-    default: T;
-    override?: Partial<ParameterizedIntegrationData<T>>;
-}): ParameterizedIntegrationData<T> {
-    return {
-        Page: options.override?.Page ?? options.default,
-        Standalone: options.override?.Standalone ?? options.default,
-        Theia: options.override?.Theia ?? options.default,
-        VSCode: options.override?.VSCode ?? options.default
-    };
-}
 
 /**
  * Runs the given callback if the active integration is the same as the provided integration type
@@ -173,4 +168,5 @@ export function skipIntegration(integrationOptions?: IntegrationOptions, ...inte
 }
 
 export { expect } from './test/assertions';
+export { DynamicVariable } from './test/dynamic-variable';
 export { test as setup };

--- a/packages/glsp-playwright/src/test/dynamic-variable.ts
+++ b/packages/glsp-playwright/src/test/dynamic-variable.ts
@@ -1,0 +1,87 @@
+/********************************************************************************
+ * Copyright (c) 2024 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import type { GLSPServer } from '../glsp-server';
+import { Integration } from '../integration';
+
+export interface DynamicVariableOptions<T> {
+    defaultValue?: T;
+    value?: Record<string, T>;
+}
+
+export interface DynamicVariable<T> {
+    getOrThrow(key: string): T;
+}
+
+export abstract class BaseDynamicVariable<T> {
+    protected readonly value: Record<string, T>;
+    protected readonly defaultValue?: T;
+
+    constructor(protected readonly options: DynamicVariableOptions<T>) {
+        this.defaultValue = options?.defaultValue;
+        this.value = options?.value ?? {};
+    }
+
+    getOrThrow(key: string): T {
+        const value = this.value[key] ?? this.defaultValue;
+        if (value === undefined) {
+            throw new Error(`No value found for key ${key}`);
+        }
+        return value;
+    }
+}
+
+export class IntegrationVariable<T> extends BaseDynamicVariable<T> {
+    protected integration?: Integration;
+
+    constructor(options: DynamicVariableOptions<T> & { integration?: Integration }) {
+        super(options);
+        this.integration = options.integration;
+    }
+
+    get(): T {
+        if (this.integration === undefined) {
+            throw new Error('No integration set');
+        }
+
+        return super.getOrThrow(this.integration.type);
+    }
+
+    setIntegration(integration: Integration): void {
+        this.integration = integration;
+    }
+}
+
+export class ServerVariable<T> extends BaseDynamicVariable<T> {
+    protected server?: GLSPServer;
+
+    constructor(options: DynamicVariableOptions<T> & { server?: GLSPServer }) {
+        super(options);
+        this.server = options.server;
+    }
+
+    get(): T {
+        if (this.server === undefined) {
+            throw new Error('No GLSP server set');
+        }
+
+        return super.getOrThrow(this.server.type);
+    }
+
+    setServer(server: GLSPServer): void {
+        this.server = server;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

Allows the test cases to use different assertions based on the used server (java / node).
Fixes https://github.com/eclipse-glsp/glsp/issues/1383

#### How to test

Let the CI run or 
1. start the java server
2. update your `.env` file to tell that we are testing the java server (see `.env.example` file)
3. execute `yarn test`

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [x] This PR should be mentioned in the changelog
- [x] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)

Removes `createParameterizedIntegrationData` - use `IntegrationVariable`, `ServerVariable` or `DynamicVariable` instead.

Examples:
- `examples/workflow-test/tests/features/validation/marker-navigator.spec.ts`  
- `examples/workflow-test/tests/features/command-palette/command-palette.spec.ts`