### PR TITLE
Fix id selectors

### DIFF
--- a/packages/glsp-playwright/src/glsp/features/routing/routing-point.po.ts
+++ b/packages/glsp-playwright/src/glsp/features/routing/routing-point.po.ts
@@ -55,7 +55,7 @@ export class RoutingPoints {
         for await (const childLocator of await this.pointsLocator.all()) {
             const id = await definedAttr(childLocator, 'id');
 
-            const routingPoint = new RoutingPoint(this.element.locator.child(`#${id}`), this);
+            const routingPoint = new RoutingPoint(this.element.locator.child(`id=${id}`), this);
             await routingPoint.snapshot();
             elements.push(routingPoint);
         }
@@ -71,7 +71,7 @@ export class RoutingPoints {
         for await (const childLocator of await this.volatilePointsLocator.all()) {
             const id = await definedAttr(childLocator, 'id');
 
-            const routingPoint = new RoutingPoint(this.element.locator.child(`#${id}`), this);
+            const routingPoint = new RoutingPoint(this.element.locator.child(`id=${id}`), this);
             await routingPoint.snapshot();
             elements.push(routingPoint);
         }

--- a/packages/glsp-playwright/src/glsp/features/tool-palette/content/tool-palette-content.po.ts
+++ b/packages/glsp-playwright/src/glsp/features/tool-palette/content/tool-palette-content.po.ts
@@ -45,7 +45,7 @@ export class GLSPToolPaletteContent {
         id: string,
         constructor: ToolPaletteContentGroupConstructor<TToolGroup>
     ): TToolGroup {
-        const toolGroupLocator = this.paletteLocator.child(`#${id}.tool-group`);
+        const toolGroupLocator = this.paletteLocator.child(`[id=${id}].tool-group`);
 
         return new constructor(toolGroupLocator, this.toolPalette);
     }

--- a/packages/glsp-playwright/src/glsp/graph/graph-semantic.po.ts
+++ b/packages/glsp-playwright/src/glsp/graph/graph-semantic.po.ts
@@ -75,8 +75,8 @@ export class GLSPSemanticGraph extends GLSPGraph {
     async getEdgesBetween<TElement extends PEdge>(
         constructor: PEdgeConstructor<TElement>,
         options: {
-            sourceNode: PEdge;
-            targetNode: PEdge;
+            sourceNode: PNode;
+            targetNode: PNode;
         }
     ): Promise<TElement[]> {
         return this.getEdgesOfType(constructor, {

--- a/packages/glsp-playwright/src/glsp/graph/graph.po.ts
+++ b/packages/glsp-playwright/src/glsp/graph/graph.po.ts
@@ -87,7 +87,7 @@ export class GLSPGraph extends PModelElement {
             if ((await childLocator.count()) > 0) {
                 const id = await childLocator.getAttribute('id');
                 if (id !== null && (await isEqualLocatorType(childLocator, constructor))) {
-                    elements.push(await this.getModelElement(`#${id}`, constructor, options));
+                    elements.push(await this.getModelElement(`id=${id}`, constructor, options));
                 }
             }
         }
@@ -133,7 +133,7 @@ export class GLSPGraph extends PModelElement {
             if ((await childLocator.count()) > 0) {
                 const id = await childLocator.getAttribute('id');
                 if (id !== null && (await isEqualLocatorType(childLocator, constructor))) {
-                    elements.push(await this.getNode(`#${id}`, constructor, options));
+                    elements.push(await this.getNode(`id=${id}`, constructor, options));
                 }
             }
         }
@@ -170,7 +170,7 @@ export class GLSPGraph extends PModelElement {
         for await (const locator of await this.locate().locator(query).all()) {
             const id = await locator.getAttribute('id');
             if (id !== null && (await isEqualLocatorType(locator, constructor))) {
-                const element = await this.getEdge(`#${id}`, constructor, options);
+                const element = await this.getEdge(`id=${id}`, constructor, options);
                 const sourceChecks = [];
                 const targetChecks = [];
 
@@ -237,7 +237,7 @@ export class GLSPGraph extends PModelElement {
             retriever = this.getEdge.bind(this) as any;
         }
 
-        return Promise.all(ids.map(id => retriever(`#${id}`, constructor)));
+        return Promise.all(ids.map(id => retriever(`id=${id}`, constructor)));
     }
 
     async waitForCreation(elementType: string, creator: () => Promise<void>): Promise<string[]> {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
Use the playwright-specific id=xyz selector instead of #yzx in graph related POs.
Reasoning: Diagram ids are user-defined and might contain characts that would required escaping with the default # selector.
e.g. if an id contains a . `my.element` selecting via # no longer works. The selector would look like this `#my.id` which would query for and element with id "my" and class "id".
Using the playwright id selector fixes this issue.

Also: Fix wrong typing of `getEdgesBeween`
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [ x] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
