### PR TITLE
Stabilize standalone e2e tests for glsp-client restyle

### DIFF
--- a/examples/workflow-test/playwright.config.ts
+++ b/examples/workflow-test/playwright.config.ts
@@ -40,7 +40,10 @@ const config: PlaywrightTestConfig<GLSPPlaywrightOptions> = {
     reporter: process.env.CI ? [['html', { open: 'never' }], ['@estruyf/github-actions-reporter']] : [['html', { open: 'never' }]],
     use: {
         actionTimeout: 0,
-        trace: 'on-first-retry'
+        trace: 'on-first-retry',
+        // Emulate `prefers-reduced-motion` so decorative entrance animations and transitions are
+        // disabled during tests.
+        contextOptions: { reducedMotion: 'reduce' }
     },
     webServer: buildWebServers(activeProjects),
     projects: buildProjects(activeProjects)

--- a/packages/glsp-playwright/src/glsp/graph/graph.po.ts
+++ b/packages/glsp-playwright/src/glsp/graph/graph.po.ts
@@ -257,7 +257,9 @@ export class GLSPGraph extends PModelElement {
             await creator();
         }).toPass();
 
-        const ignore = ['.ghost-element', ...ids.map(id => `[id="${id}"]`)];
+        // Exclude transient creation feedback in addition to the already-present elements.
+        // This ensures stability against timing issues under load
+        const ignore = ['.ghost-element', '.feedback-edge', ...ids.map(id => `[id="${id}"]`)];
         const createdLocator = this.locate().locator(`[data-svg-metadata-type="${elementType}"]:not(${ignore.join(',')})`);
 
         await expect(createdLocator.first()).toBeVisible();


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
- Exclude transient `.feedback-edge` preview in Graph.waitForCreation to fix edge-creation flakiness
- Enable reducedMotion in Playwright config to stabilize transition-sensitive interactions
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
