### PR TITLE
GLSP-1636: Fix Theia e2e web-server launch across yarn and pnpm

### DIFF
--- a/examples/workflow-test/configs/utils.ts
+++ b/examples/workflow-test/configs/utils.ts
@@ -45,6 +45,16 @@ export function getRepoPath(repoName: string): string {
     return path.resolve(getRepoDir(), repoName);
 }
 
+// TEMPORARY: remove once all GLSP repos are migrated to pnpm.
+// During the migration a cloned integration repo may still be yarn-based. The package manager
+// determines how a binary is launched in a sub-package: pnpm's script shorthand only runs
+// package.json scripts, so the `theia` binary must be invoked via `pnpm exec`, whereas yarn classic
+// runs binaries directly and has no `exec` command. Detect the lockfile so callers can adapt.
+// Mirrors the yarn.lock-based detection in scripts/setup.ts.
+export function isYarnRepo(repoName: string): boolean {
+    return existsSync(path.resolve(getRepoPath(repoName), 'yarn.lock'));
+}
+
 export function getPort(envVar: string): number {
     const val = process.env[envVar];
     if (val) {

--- a/examples/workflow-test/configs/webserver.config.ts
+++ b/examples/workflow-test/configs/webserver.config.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { PlaywrightTestConfig } from '@playwright/test';
-import { ProjectName, getBrowserServerBundlePath, getPort, getRepoDir, needsGlspServer } from './utils';
+import { ProjectName, getBrowserServerBundlePath, getPort, getRepoDir, isYarnRepo, needsGlspServer } from './utils';
 
 type WebServerConfig = Extract<NonNullable<PlaywrightTestConfig['webServer']>, unknown[]>[number];
 
@@ -41,6 +41,7 @@ export function buildWebServers(activeProjects: ProjectName[]): PlaywrightTestCo
     const standaloneBrowserPort = getPort('STANDALONE_BROWSER_PORT');
     const theiaPort = getPort('THEIA_PORT');
     const browserServerBundle = getBrowserServerBundlePath();
+    const theiaBin = isYarnRepo('glsp-theia-integration') ? 'theia' : 'exec theia';
     const configs: Partial<Record<ProjectName, ProjectServerConfig>> = {
         standalone: {
             command: `${repo} client start --external-server --no-open`,
@@ -55,7 +56,12 @@ export function buildWebServers(activeProjects: ProjectName[]): PlaywrightTestCo
             path: '/diagram.html'
         },
         theia: {
-            command: `${repo} theia run browser theia start --WF_GLSP=${glspServerPort} --WF_PATH=workflow --glspDebug`,
+            // TEMPORARY: drop the `isYarnRepo` branch once glsp-theia-integration is migrated to pnpm.
+            // The command resolves to `<pm> browser <exec?> theia start ...` in the cloned repo. Under
+            // pnpm the `theia` binary must be launched via `pnpm exec` (the script shorthand only runs
+            // package.json scripts, else it fails with ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL); yarn classic
+            // runs binaries directly and has no `exec` command.
+            command: `${repo} theia run browser ${theiaBin} start --WF_GLSP=${glspServerPort} --WF_PATH=workflow --glspDebug`,
             port: theiaPort
         }
     };


### PR DESCRIPTION
#### What it does

Follow-up to the pnpm migration (#58). The `theia` Playwright project's web-server launches the `theia` binary inside the cloned `glsp-theia-integration` repo. The two package managers disagree on how to do that:

- **pnpm** — the script shorthand only runs package.json scripts, so the binary must be invoked via `pnpm exec`; launching it directly fails with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL`.
- **yarn classic** — runs binaries directly and has **no** `exec` command, so adding `exec` makes the web-server exit early.

Because the e2e clones the integration repo's **default branch** (still yarn mid-migration), no single literal command works for both. The web-server failure was invisible in logs (`stdout`/`stderr: 'ignore'`); it only surfaced as `Process from config.webServer was not able to start / exited early` with zero tests.

Fix: detect the cloned repo's package manager via its lockfile (`isYarnRepo`, mirroring the existing detection in `scripts/setup.ts`) and add `exec` only for pnpm.

This is a **temporary** workaround, to be removed together with the existing yarn `packageManager`-pinning workaround in `scripts/setup.ts` once all GLSP repos are on pnpm.

Part of: eclipse-glsp/glsp#1636

#### How to test

- `pnpm test:theia` against a **yarn** glsp-theia-integration checkout (current `main`) and against a **pnpm** checkout (the migration branch). The Theia app web-server should boot in both cases (`Theia app listening on http://127.0.0.1:3000`) and the suite should run.
- The `Node / theia` and `Java / theia` CI jobs should go green.

#### Follow-ups

- Remove the `isYarnRepo` branch here and the yarn `packageManager` pinning in `scripts/setup.ts` once the pnpm migration of all GLSP repos is complete.

#### Changelog

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
