### PR TITLE
GLSP-1636: Remove yarn-compatibility workarounds for pnpm migration

### DIFF
--- a/examples/workflow-test/configs/utils.ts
+++ b/examples/workflow-test/configs/utils.ts
@@ -45,16 +45,6 @@ export function getRepoPath(repoName: string): string {
     return path.resolve(getRepoDir(), repoName);
 }
 
-// TEMPORARY: remove once all GLSP repos are migrated to pnpm.
-// During the migration a cloned integration repo may still be yarn-based. The package manager
-// determines how a binary is launched in a sub-package: pnpm's script shorthand only runs
-// package.json scripts, so the `theia` binary must be invoked via `pnpm exec`, whereas yarn classic
-// runs binaries directly and has no `exec` command. Detect the lockfile so callers can adapt.
-// Mirrors the yarn.lock-based detection in scripts/setup.ts.
-export function isYarnRepo(repoName: string): boolean {
-    return existsSync(path.resolve(getRepoPath(repoName), 'yarn.lock'));
-}
-
 export function getPort(envVar: string): number {
     const val = process.env[envVar];
     if (val) {

--- a/examples/workflow-test/configs/webserver.config.ts
+++ b/examples/workflow-test/configs/webserver.config.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { PlaywrightTestConfig } from '@playwright/test';
-import { ProjectName, getBrowserServerBundlePath, getPort, getRepoDir, isYarnRepo, needsGlspServer } from './utils';
+import { ProjectName, getBrowserServerBundlePath, getPort, getRepoDir, needsGlspServer } from './utils';
 
 type WebServerConfig = Extract<NonNullable<PlaywrightTestConfig['webServer']>, unknown[]>[number];
 
@@ -41,7 +41,6 @@ export function buildWebServers(activeProjects: ProjectName[]): PlaywrightTestCo
     const standaloneBrowserPort = getPort('STANDALONE_BROWSER_PORT');
     const theiaPort = getPort('THEIA_PORT');
     const browserServerBundle = getBrowserServerBundlePath();
-    const theiaBin = isYarnRepo('glsp-theia-integration') ? 'theia' : 'exec theia';
     const configs: Partial<Record<ProjectName, ProjectServerConfig>> = {
         standalone: {
             command: `${repo} client start --external-server --no-open`,
@@ -56,12 +55,7 @@ export function buildWebServers(activeProjects: ProjectName[]): PlaywrightTestCo
             path: '/diagram.html'
         },
         theia: {
-            // TEMPORARY: drop the `isYarnRepo` branch once glsp-theia-integration is migrated to pnpm.
-            // The command resolves to `<pm> browser <exec?> theia start ...` in the cloned repo. Under
-            // pnpm the `theia` binary must be launched via `pnpm exec` (the script shorthand only runs
-            // package.json scripts, else it fails with ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL); yarn classic
-            // runs binaries directly and has no `exec` command.
-            command: `${repo} theia run browser ${theiaBin} start --WF_GLSP=${glspServerPort} --WF_PATH=workflow --glspDebug`,
+            command: `${repo} theia run browser exec theia start --WF_GLSP=${glspServerPort} --WF_PATH=workflow --glspDebug`,
             port: theiaPort
         }
     };

--- a/examples/workflow-test/scripts/setup.ts
+++ b/examples/workflow-test/scripts/setup.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { execSync } from 'child_process';
-import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { copyFileSync, readFileSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
 
 const args = process.argv.slice(2);
@@ -55,36 +55,6 @@ if (vscode || all) {
 }
 
 run(`${repo} clone ${repos.join(' ')}`);
-
-if (repos.includes('glsp-vscode-integration')) {
-    // The glsp-vscode-integration repo is a lerna monorepo that gets cloned into the `.repositories`
-    // directory of this (also lerna-based) repo. Without an `nx.json` marking the repo root, lerna
-    // walks up the directory tree, detects the nesting and fails. Adding an empty `nx.json` tells
-    // lerna to stop the lookup at the repo root.
-    const nxJson = resolve(rootDir, '.repositories', 'glsp-vscode-integration', 'nx.json');
-    console.log(`Adding ${nxJson}`);
-    writeFileSync(nxJson, '{}');
-}
-
-// TEMPORARY: remove once all GLSP repos are migrated to pnpm.
-// Yarn classic (1.x) walks up the directory tree looking for a `packageManager` field. Since this
-// repo's root package.json declares `pnpm@<version>`, a `yarn install` inside a cloned (yarn-based)
-// repo under `.repositories` would find that pnpm pin, misparse it as `yarn@pnpm@<version>`, and
-// abort. Pin each cloned yarn repo to the local yarn version so the lookup stops at the repo itself.
-const yarnVersion = execSync('yarn --version', { cwd: rootDir }).toString().trim();
-for (const cloned of repos) {
-    const repoDir = resolve(rootDir, '.repositories', cloned);
-    const pkgPath = resolve(repoDir, 'package.json');
-    if (!existsSync(resolve(repoDir, 'yarn.lock')) || !existsSync(pkgPath)) {
-        continue;
-    }
-    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-    if (!pkg.packageManager) {
-        pkg.packageManager = `yarn@${yarnVersion}`;
-        writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
-        console.log(`Pinned ${cloned} packageManager to yarn@${yarnVersion}`);
-    }
-}
 
 if (!skipBuild) {
     run(`${repo} build`);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

The pnpm migration introduced temporary workarounds to stay compatible with
GLSP repos that were still yarn-based mid-migration. Now that all repos are on
pnpm, these are no longer needed:

- Remove the `yarn.lock` detection (`isYarnRepo`) and always launch the `theia`
  binary via `pnpm exec` in the e2e web-server config
- Stop pinning cloned yarn repos' `packageManager` field in `setup.ts`
- Drop the `nx.json` workaround for the cloned `glsp-vscode-integration` repo,
  no longer lerna-based after its pnpm migration

Part of: eclipse-glsp/glsp#1636

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- [x] `pnpm build`, lint, format, and header checks pass locally
- Run the Theia e2e suite (`/test theia`) and confirm the web-server launches
  against the freshly cloned, pnpm-based integration repos

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
